### PR TITLE
feat: build_all_standards.sh is a new script now 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ Makefile
 *.swp
 *.swo
 
+# Ignore logs from build_all_standard.sh
+logs/
+
 # Ignore binary/object/library files
 *.o
 *.obj

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2025 The Heimdall Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/bash
+
 
 # Heimdall Clean Script
 # This script removes all build artifacts for a clean checkout
@@ -180,6 +181,13 @@ if [[ -d "tests/temp" ]]; then
     print_status "Removing test output directory"
     rm -rf "tests/temp"
     print_success "Test output directory removed"
+fi
+
+# clean log files
+if [[ -d "logs" ]]; then
+    print_status "Removing build log files"
+    rm -rf "logs/"
+    print_success "Build log files removed"
 fi
 
 # Clean any stray build artifacts


### PR DESCRIPTION
It should work regardless of build.sh changing

* as long as it says "Heimdall C++$standard build completed successfully!" where standard is C++ standard we are building update: clean.sh now cleans log files from build_all_standards.sh and .gitignore ignores logs

## Description

Build_all_stanards.sh will now use build.sh to build all of the cpp standards with their compilers too. 
* I don't have a mac as of testing right now, but im assuming clang will just count as a fail

**Fixes**: #95 

## Type of Change

Please delete options that are not relevant.

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **New feature** (non-breaking change which adds functionality)
- [X] **Build system change** (changes to build scripts, CI/CD)

## Test Commands

```bash
# Commands used to test the changes
./scripts/build_all_standards.sh
```

### Build and Test Results

<img width="686" height="627" alt="image" src="https://github.com/user-attachments/assets/be814e59-eb50-44e2-a6d9-3f045d725945" />
